### PR TITLE
removed check for data that may not exist on Google

### DIFF
--- a/Code/WorldDomination.Web.Authentication/Google/GoogleProvider.cs
+++ b/Code/WorldDomination.Web.Authentication/Google/GoogleProvider.cs
@@ -187,13 +187,10 @@ namespace WorldDomination.Web.Authentication.Google
             }
 
             // Lets check to make sure we have some bare minimum data.
-            if (string.IsNullOrEmpty(response.Data.Id) ||
-                string.IsNullOrEmpty(response.Data.Email) ||
-                string.IsNullOrEmpty(response.Data.Name) ||
-                string.IsNullOrEmpty(response.Data.Locale))
+            if (string.IsNullOrEmpty(response.Data.Id))
             {
                 throw new AuthenticationException(
-                    "Retrieve some user info from the Google Api, but we're missing one or more of either: Id, Email, Name and Locale.");
+                    "We were unable to retrieve the User Id from Google API, the user may have denied the authorization.");
             }
 
             return response.Data;


### PR DESCRIPTION
It seems in some cases Google doesn't supply anything other than the Id so I've removed the checks, otherwise users fail to login.

If a developer requires that information he will need to request it from the user himself or use the Google API to manually fetch that shit.
