### PR TITLE
Scope added for Github Provider

### DIFF
--- a/Code/WorldDomination.Web.Authentication.ExtraProviders/GitHub/GitHubAuthenticationServiceSettings.cs
+++ b/Code/WorldDomination.Web.Authentication.ExtraProviders/GitHub/GitHubAuthenticationServiceSettings.cs
@@ -2,8 +2,17 @@
 {
     public class GitHubAuthenticationServiceSettings : BaseAuthenticationServiceSettings
     {
+        private string scope = "user:email";
+
         public GitHubAuthenticationServiceSettings() : base("github")
         {
         }
+
+        public string Scope
+        {
+            get { return scope; }
+            set { scope = value; } 
+        }
+        
     }
 }

--- a/Code/WorldDomination.Web.Authentication.ExtraProviders/GitHubProvider.cs
+++ b/Code/WorldDomination.Web.Authentication.ExtraProviders/GitHubProvider.cs
@@ -185,7 +185,7 @@ namespace WorldDomination.Web.Authentication.ExtraProviders
 
             var oauthDialogUri =
                 string.Format(
-                    "https://github.com/login/oauth/authorize?client_id={0}&scope=user:email&redirect_uri={1}&response_type=code{2}",
+                    "https://github.com/login/oauth/authorize?client_id={0}&scope=" + ((GitHubAuthenticationServiceSettings)DefaultAuthenticationServiceSettings).Scope + "&redirect_uri={1}&response_type=code{2}",
                     _clientId, authenticationServiceSettings.CallBackUri.AbsoluteUri, state);
 
             return new Uri(oauthDialogUri);


### PR DESCRIPTION
For Sandra Snow I need public access to Github repos to able to write back to the repos ie/git push, for this I need elevated access which is "repo" and at the mo WD only uses "user:email".

This PR allows the user to set the scope settings programtaically
