### PR TITLE
Fix SimpleAuthenticationController not constructing

### DIFF
--- a/Code/SimpleAuthentication.Mvc/SimpleAuthenticationController.cs
+++ b/Code/SimpleAuthentication.Mvc/SimpleAuthenticationController.cs
@@ -16,32 +16,23 @@ namespace SimpleAuthentication.Mvc
 
         private readonly AuthenticationProviderFactory _authenticationProviderFactory;
 
-        public SimpleAuthenticationController()
+        public SimpleAuthenticationController(IAuthenticationCallbackProvider callbackProvider)
         {
             // Lazyily setup our TraceManager.
             TraceManager = new Lazy<ITraceManager>(() => new TraceManager()).Value;
 
-            if (CallbackProvider == null)
+            if (callbackProvider == null)
             {
 
                 // We don't have the bare minimum requirements - so lets help the developer.
-                const string errorMessage =
-                    "Please use the SimpleAuthenticationController(IAuthenticationCallbackProvider) constructor. This is because we need to know what to do AFTER we've retrieved the User Information from the Authentication Provider. This is normally done by leveraging the ASP.NET MVC Dependency Resolver. So please pick a form of Dependency Injection and inject an IAuthenticationCallbackProvider into this constructor. For more information about ASP.NET MVC's Dependency Resolver: http://www.asp.net/mvc/tutorials/hands-on-labs/aspnet-mvc-4-dependency-injection .";
+                string errorMessage =
+                    "Please provide a callback provider (IAuthenticationCallbackProvider). This is because we need to know what to do AFTER we've retrieved the User Information from the Authentication Provider. This is normally done by leveraging the ASP.NET MVC Dependency Resolver. So please pick a form of Dependency Injection and inject an IAuthenticationCallbackProvider into this constructor. For more information about ASP.NET MVC's Dependency Resolver: http://www.asp.net/mvc/tutorials/hands-on-labs/aspnet-mvc-4-dependency-injection .";
                 TraceSource.TraceError(errorMessage);
-                throw new NotImplementedException(errorMessage);
-            }
-
-            _authenticationProviderFactory = new AuthenticationProviderFactory();
-        }
-
-        public SimpleAuthenticationController(IAuthenticationCallbackProvider callbackProvider) : this()
-        {
-            if (callbackProvider == null)
-            {
-                throw new ArgumentNullException("callbackProvider");
+                throw new ArgumentNullException("callbackProvider", errorMessage);
             }
 
             CallbackProvider = callbackProvider;
+            _authenticationProviderFactory = new AuthenticationProviderFactory();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue #77

The problem is that the callback provider ctor hands off control to the default ctor. But that default ctor runs before the CallbackProvider property gets to be set. The default ctor expects the CallbackProvider property to be set, which because of the call order it will never be set.
