### PR TITLE
Changing System.Web.Mvc reference from v4 to v3.

### DIFF
--- a/Code/SimpleAuthentication.Mvc/SimpleAuthentication.Mvc.csproj
+++ b/Code/SimpleAuthentication.Mvc/SimpleAuthentication.Mvc.csproj
@@ -43,7 +43,10 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\AspNetMvc.3.0.20105.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.Razor.2.0.20715.0\lib\net40\System.Web.Razor.dll</HintPath>

--- a/Code/SimpleAuthentication.Mvc/packages.config
+++ b/Code/SimpleAuthentication.Mvc/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AspNetMvc" version="3.0.20105.0" targetFramework="net40" />
+  <package id="AspNetRazor.Core" version="1.0.20105.408" targetFramework="net40" />
+  <package id="AspNetWebPages.Core" version="1.0.20105.408" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />


### PR DESCRIPTION
It seems going from version 4 of Mvc to 3 doesn't break anything, so why not?

I would really like to use SimpleAuthentication with MVC Forum, and it is still based on Mvc 3.
