### PR TITLE
Fixed typo when adding provider from appSettings (fixes #119).

### DIFF
--- a/Code/SimpleAuthentication.Core/Config/AppSettingsParser.cs
+++ b/Code/SimpleAuthentication.Core/Config/AppSettingsParser.cs
@@ -46,7 +46,7 @@
                             configuration.Providers = new List<Provider>();
                         }
 
-                        configuration.Providers.Add(ParseValueForProviderData(key, value));
+                        configuration.Providers.Add(ParseValueForProviderData(provider, value));
                         break;
                 }
             }


### PR DESCRIPTION
There was a typo when adding provider discovered from appSettings - the provider name would include the "sa:" prefix which immediately caused an exception since no such providers exist (see #119). Simple fix though.
