### PR TITLE
Make 'providerkey' querystring parameter lowercase to fix #120.

### DIFF
--- a/Code/Nancy.SimpleAuthentication/SimpleAuthenticationModule.cs
+++ b/Code/Nancy.SimpleAuthentication/SimpleAuthenticationModule.cs
@@ -122,7 +122,7 @@ namespace Nancy.SimpleAuthentication
 
         private dynamic AuthenticateCallback()
         {
-            var providerKey = (string) Request.Query.providerKey;
+            var providerKey = (string) Request.Query.providerkey;
             if (string.IsNullOrEmpty(providerKey))
             {
                 throw new ArgumentException(


### PR DESCRIPTION
According to my tests this simple change fixes #120 (and thus makes Nancy.SimpleAuthentication work when `StaticConfiguration.CaseSensitive = true`). Can't really think of a scenario where this would break anything either; if your app is not case sensitive it doesn't matter and if it is it didn't work before this.

Also, as far as I can see it won't matter what case the provider uses for the relevant parameter names sent to the callback url since [they are all put in a `NameValueCollection`](https://github.com/SimpleAuthentication/SimpleAuthentication/blob/b80b02f5223fe9ddd9d57b13851236b8f6dd077a/Code/Nancy.SimpleAuthentication/SimpleAuthenticationModule.cs#L160) (which is case-insensitive by default) before being passed to the `IAuthenticationProvider` implementation.
