### PR TITLE
Lowercase Uri for Facebook during ExecuteRetrieveAccessToken

### DIFF
--- a/Code/SimpleAuthentication.Core/Providers/FacebookProvider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/FacebookProvider.cs
@@ -115,7 +115,7 @@ namespace SimpleAuthentication.Core.Providers
             restRequest.AddParameter("client_id", PublicApiKey);
             restRequest.AddParameter("client_secret", SecretApiKey);
             restRequest.AddParameter("code", authorizationCode);
-            restRequest.AddParameter("redirect_uri", redirectUri.AbsoluteUri);
+            restRequest.AddParameter("redirect_uri", redirectUri.AbsoluteUri.ToLowerInvariant());
             restRequest.AddHeader("Content-Type", "application/json");
             restRequest.AddParameter("format", "json");
 


### PR DESCRIPTION
Steps to reproduce using SimpleAuthentication.Sample.MvcAuto :
1. In SimpleAuthentication.Mvc => SimpleAuthenticationRouteConfig.cs change DefaultCallbackRoute to "Authentication/AuthenticateCallback"
2. Run the sample and log on using Facebook. This results in the error: Error validating verification code. Please make sure your redirect_uri is identical to the one you used in the OAuth dialog request

This error happens because of the different (lower vs uppercase) redirect_uri in the dialog/oauth call and the oauth/access_token call.
