### PR TITLE
Removed reference of Session object in CookieCache

### DIFF
--- a/Code/SimpleAuthentication.Mvc/Caching/CookieCache.cs
+++ b/Code/SimpleAuthentication.Mvc/Caching/CookieCache.cs
@@ -36,8 +36,7 @@ namespace SimpleAuthentication.Mvc.Caching
 
         public void Initialize()
         {
-            if (HttpContext.Current != null &&
-                HttpContext.Current.Session != null)
+            if (HttpContext.Current != null)
             {
                 _httpContext = HttpContext.Current;
             }


### PR DESCRIPTION
- Session object isn't required in this instance and will break
  cookie cache when sessionstate is disabled
