### PR TITLE
Missing basepath in callback redirections in Nancy

### DIFF
--- a/Code/Nancy.SimpleAuthentication/SimpleAuthenticationModule.cs
+++ b/Code/Nancy.SimpleAuthentication/SimpleAuthenticationModule.cs
@@ -230,7 +230,7 @@ namespace Nancy.SimpleAuthentication
 
         private Uri GenerateCallbackUri(string providerName)
         {
-            return SystemHelpers.CreateCallBackUri(providerName, Request.Url, CallbackRoute);
+            return SystemHelpers.CreateCallBackUri(providerName, Request.Url, Request.Url.BasePath + CallbackRoute);
         }
 
         private string DetermineReturnUrl()


### PR DESCRIPTION
Nancy supports subdirectory structures like `http://some_domain:1234/some_sub_dir/authentication/redirect/some_provider`. But while using this in SimpleAuthentication I noticed that the callback redirections were linked to a location without subdirectories, like: `http://some_domain:1234/authentication/authenticatecallback`.

This small change should fix the problem: it prepends the callback route with the basepath of the URL. If there's no basepath, there won't be any prefixes as basepath will be null and therefore substituted with an empty string.
