### PR TITLE
Fix string.format on authorization code failure.  Addresses #146

### DIFF
--- a/Code/SimpleAuthentication.Core/Providers/BaseOAuth20Provider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/BaseOAuth20Provider.cs
@@ -210,8 +210,7 @@ namespace SimpleAuthentication.Core.Providers
             if (!string.IsNullOrEmpty(error))
             {
                 var errorMessage =
-                    string.Format("Failed to retrieve an authorization code from {0}. The error provided is: {1}" +
-                                  Name, error);
+                    string.Format("Failed to retrieve an authorization code from {0}. The error provided is: {1}", Name, error);
                 TraceSource.TraceError(errorMessage);
                 throw new AuthenticationException(errorMessage);
             }


### PR DESCRIPTION
The error that's returned makes more sense now:
![croppercapture 3](https://cloud.githubusercontent.com/assets/1271535/3484149/8f517a2a-03a0-11e4-845e-30e66b180f6e.jpg)
