### PR TITLE
Fix to work with mono

### DIFF
--- a/Code/SimpleAuthentication.Core/Config/ProviderConfigurationHelper.cs
+++ b/Code/SimpleAuthentication.Core/Config/ProviderConfigurationHelper.cs
@@ -64,25 +64,25 @@ namespace SimpleAuthentication.Core.Config
             {
                 throw new ArgumentNullException(sectionName);
             }
-            
+
             var configSection = ConfigurationManager.GetSection(sectionName) as ProviderConfiguration;
             return configSection == null ||
                    configSection.Providers == null ||
                    configSection.Providers.Count <= 0
                        ? null
                        : new Configuration
-                         {
-                             RedirectRoute = configSection.RedirectRoute,
-                             CallBackRoute = configSection.CallbackRoute,
-                             Providers = (from p in configSection.Providers.AllKeys
-                                          select new Provider
-                                                 {
-                                                     Name = configSection.Providers[p].Name,
-                                                     Key = configSection.Providers[p].Key,
-                                                     Secret = configSection.Providers[p].Secret,
-                                                     Scopes = configSection.Providers[p].Scope
-                                                 }).ToList()
-                         };
+                       {
+                           RedirectRoute = configSection.RedirectRoute,
+                           CallBackRoute = configSection.CallbackRoute,
+                           Providers = (from p in configSection.Providers.Cast<ProviderKey>().Select(x => x.Name)
+                                        select new Provider
+                                        {
+                                            Name = configSection.Providers[p].Name,
+                                            Key = configSection.Providers[p].Key,
+                                            Secret = configSection.Providers[p].Secret,
+                                            Scopes = configSection.Providers[p].Scope
+                                        }).ToList()
+                       };
         }
 
         public static ProviderKey For(this ProviderConfiguration section, string providerKey)

--- a/Code/SimpleAuthentication.Core/ReflectionHelpers.cs
+++ b/Code/SimpleAuthentication.Core/ReflectionHelpers.cs
@@ -51,7 +51,11 @@ namespace SimpleAuthentication.Core
 
         public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
         {
-            if (assembly == null) throw new ArgumentNullException("assembly");
+            if (assembly == null)
+            {
+                throw new ArgumentNullException("assembly");
+            }
+            
             try
             {
                 return assembly.GetTypes();

--- a/Code/SimpleAuthentication.Core/ReflectionHelpers.cs
+++ b/Code/SimpleAuthentication.Core/ReflectionHelpers.cs
@@ -13,12 +13,12 @@ namespace SimpleAuthentication.Core
         {
             try
             {
-                var type = typeof (T);
+                var type = typeof(T);
 
                 return AppDomain.CurrentDomain
                     .GetAssemblies()
                     .ToList()
-                    .SelectMany(s => s.GetTypes())
+                    .SelectMany(s => s.GetLoadableTypes())
                     .Where(p => type.IsAssignableFrom(p) &&
                                 p.IsClass &&
                                 !p.IsAbstract &&
@@ -46,6 +46,19 @@ namespace SimpleAuthentication.Core
                 throw new Exception(
                     "Failed to reflect on the current domain's Assemblies while searching for plugins. Error Message: " +
                     stringBuilder);
+            }
+        }
+
+        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+        {
+            if (assembly == null) throw new ArgumentNullException("assembly");
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null);
             }
         }
     }


### PR DESCRIPTION
#139 changed the way the key is obtained from the configSection

Added a new method in ReflectionHelpers `GetLoadableTypes`  that solves
this question in stackoverflow
http://stackoverflow.com/questions/30471563/simpleauthencation-throwing-failed-to-reflect-on-the-current-domains-assemblie
based in this post
http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/