### PR TITLE
Expand TwitterProvider with SecretToken

### DIFF
--- a/Code/SimpleAuthentication.Core/Providers/TwitterProvider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/TwitterProvider.cs
@@ -366,7 +366,8 @@ namespace SimpleAuthentication.Core.Providers
                 },
                 AccessToken = new AccessToken
                 {
-                    PublicToken = oAuthAccessToken.AccessToken
+                    PublicToken = oAuthAccessToken.AccessToken,
+                    SecretToken = oAuthAccessToken.AccessTokenSecret
                 }
             };
         }


### PR DESCRIPTION
Currently the Twitter Provider is not populating the Secret Token, hence, there is no way to make additional calls upon  authorization to the twitter api.

This change is to set the secret token.