### PR TITLE
Adjusted dependency versions

### DIFF
--- a/Code/SimpleAuthentication.Core/SimpleAuthentication.Core.csproj
+++ b/Code/SimpleAuthentication.Core/SimpleAuthentication.Core.csproj
@@ -31,7 +31,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RestSharp" Version="106.15.0" />
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     </ItemGroup>
 
 </Project>

--- a/Code/SimpleAuthentication.ExtraProviders/SimpleAuthentication.ExtraProviders.csproj
+++ b/Code/SimpleAuthentication.ExtraProviders/SimpleAuthentication.ExtraProviders.csproj
@@ -39,7 +39,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RestSharp" Version="106.15.0" />
-        <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
+        <PackageReference Include="System.Runtime.Caching" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Moved `System.Configuration.ConfigurationManager` from `7.0.0` to `4.7.0`.
- Moved `System.Runtime.Caching` from `7.0.0` to `4.7.0`.

This makes the minimum dependency 4.7.0 and prevents the user from needing to pre-maturely upgrade the dependency until they are ready.
