### PR TITLE
Google prompt select account

### DIFF
--- a/Code/SimpleAuthentication.Core/Providers/Google/GoogleProviderParams.cs
+++ b/Code/SimpleAuthentication.Core/Providers/Google/GoogleProviderParams.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleAuthentication.Core.Providers.Google
+{
+    public class GoogleProviderParams : ProviderParams
+    {
+        public string PromptType { get; set; }
+    }
+}

--- a/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
@@ -16,7 +16,7 @@ namespace SimpleAuthentication.Core.Providers
         private const string AccessTokenKey = "access_token";
         private const string ExpiresInKey = "expires_in";
         private const string TokenTypeKey = "token_type";
-        private string _promptType;
+        private readonly string _promptType;
 
         public GoogleProvider(ProviderParams providerParams) : this("Google", providerParams)
         {
@@ -24,8 +24,8 @@ namespace SimpleAuthentication.Core.Providers
 
         public GoogleProvider(GoogleProviderParams providerParams) : this("Google", providerParams)
         {
+            if (!string.IsNullOrWhiteSpace(providerParams?.PromptType))
 
-            if (!string.IsNullOrEmpty(providerParams?.PromptType))
             {
                 _promptType = providerParams.PromptType;
             }

--- a/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
@@ -16,9 +16,19 @@ namespace SimpleAuthentication.Core.Providers
         private const string AccessTokenKey = "access_token";
         private const string ExpiresInKey = "expires_in";
         private const string TokenTypeKey = "token_type";
+        private string _promptType;
 
         public GoogleProvider(ProviderParams providerParams) : this("Google", providerParams)
         {
+        }
+
+        public GoogleProvider(GoogleProviderParams providerParams) : this("Google", providerParams)
+        {
+
+            if (!string.IsNullOrEmpty(providerParams?.PromptType))
+            {
+                _promptType = providerParams.PromptType;
+            }
         }
 
         protected GoogleProvider(string name, ProviderParams providerParams) : base(name, providerParams)
@@ -48,6 +58,11 @@ namespace SimpleAuthentication.Core.Providers
             restRequest.AddParameter("redirect_uri", redirectUri.AbsoluteUri);
             restRequest.AddParameter("code", authorizationCode);
             restRequest.AddParameter("grant_type", "authorization_code");
+
+            if (!string.IsNullOrWhiteSpace(_promptType))
+            {
+                restRequest.AddParameter("prompt", _promptType);
+            }
 
             var restClient = RestClientFactory.CreateRestClient("https://accounts.google.com");
             TraceSource.TraceVerbose("Retrieving Access Token endpoint: {0}",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "7.0.100",
+        "version": "8.0.100",
         "rollForward": "latestFeature"
     }
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.100",
+        "version": "7.0.100",
         "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Allows users to add an option for the prompt query param for Google auth.

example:

`<url>?prompt=select_account`