### PR TITLE
Fix prompt for Google login

### DIFF
--- a/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
+++ b/Code/SimpleAuthentication.Core/Providers/GoogleProvider.cs
@@ -59,11 +59,6 @@ namespace SimpleAuthentication.Core.Providers
             restRequest.AddParameter("code", authorizationCode);
             restRequest.AddParameter("grant_type", "authorization_code");
 
-            if (!string.IsNullOrWhiteSpace(_promptType))
-            {
-                restRequest.AddParameter("prompt", _promptType);
-            }
-
             var restClient = RestClientFactory.CreateRestClient("https://accounts.google.com");
             TraceSource.TraceVerbose("Retrieving Access Token endpoint: {0}",
                                      restClient.BuildUri(restRequest).AbsoluteUri);
@@ -170,6 +165,17 @@ namespace SimpleAuthentication.Core.Providers
                 Picture = response.Data.Picture,
                 UserName = response.Data.Name
             };
+        }
+
+        protected override string CreateRedirectionQuerystringParameters(Uri callbackUri, string state)
+        {
+            var url = base.CreateRedirectionQuerystringParameters(callbackUri, state);
+
+            var promptType = string.IsNullOrWhiteSpace(_promptType)
+                             ? string.Empty
+                             : string.Format("&prompt={0}", _promptType);
+
+            return string.Format("{0}{1}", url, promptType);
         }
 
         #endregion


### PR DESCRIPTION
A way to add the `prompt` param to the `AuthenticateRedirectionUrl` params, for Google auth only.

- Remove `prompt` from token url generation. This was the wrong place 😓.
- Add `prompt` via override of `CreateRedirectionQuerystringParameters` in `GoogleProvider` to append on to end of `redirectUrl` in `BaseOAuth20Provider` to allow Google to pick up the param.